### PR TITLE
Fix win32 temp path

### DIFF
--- a/KindleTool/kindle_tool.h
+++ b/KindleTool/kindle_tool.h
@@ -88,8 +88,9 @@
 #define IS_UIMAGE(filename) (strncmp(filename+(strlen(filename)-6), "uImage", 6) == 0)
 
 // Don't break tempfiles on Win32... (it doesn't like paths starting with // because that means an 'extended' path (network shares and more weird stuff like that), but P_tmpdir defaults to / on Win32, and we prepend our own constants with / because it's /tmp on POSIX...)
+// Geekmaster update: Don't put tempfile on drive root ("/" gives permission violation), but use "./" (current dir) instead.
 #if defined(_WIN32) && !defined(__CYGWIN__)
-#define KT_TMPDIR ""
+#define KT_TMPDIR "."
 #else
 #define KT_TMPDIR P_tmpdir
 #endif


### PR DESCRIPTION
Not tested (no toolchain installed), but changed Win32 temp folder from
"" to "." to prevent permission violation (mingw x64 kindletool.exe)
when doing extract.