### PR TITLE
Update kindle_tool.h

### DIFF
--- a/KindleTool/kindle_tool.h
+++ b/KindleTool/kindle_tool.h
@@ -88,9 +88,9 @@
 #define IS_UIMAGE(filename) (strncmp(filename+(strlen(filename)-6), "uImage", 6) == 0)
 
 // Don't break tempfiles on Win32... (it doesn't like paths starting with // because that means an 'extended' path (network shares and more weird stuff like that), but P_tmpdir defaults to / on Win32, and we prepend our own constants with / because it's /tmp on POSIX...)
-// Geekmaster update: Don't put tempfile on drive root ("/" gives permission violation), but use "./" (current dir) instead.
+// Geekmaster update: Don't put tempfile on drive root ("/" gives permission violation), but use "../" (parent dir) instead. Current dir fails on OTA2 updates.
 #if defined(_WIN32) && !defined(__CYGWIN__)
-#define KT_TMPDIR "."
+#define KT_TMPDIR ".."
 #else
 #define KT_TMPDIR P_tmpdir
 #endif


### PR DESCRIPTION
After we changed temp path for win32 from "" to "." it worked for OTA create, but still fails on OTA2 create (which appears to move files from current dir to temp dir). This patch changes "." to ".." (parent folder) which will work as long as current dir is two or more levels deep from root dir. I await a binary to test... 