### PR TITLE
Update create.c to respect command line source and target revisions w…

### DIFF
--- a/KindleTool/create.c
+++ b/KindleTool/create.c
@@ -1316,6 +1316,7 @@ int kindle_create_main(int argc, char *argv[])
     FILE *input = NULL;
     FILE *output = stdout;
     int i;
+    char sourceRevFlag=0, targetRevFlag=0;
     unsigned int ui;
     char *output_filename = NULL;
     char **input_list = NULL;
@@ -2062,9 +2063,11 @@ int kindle_create_main(int argc, char *argv[])
                 break;
             case 's':
                 info.source_revision = strtoull(optarg, NULL, 0);
+                sourceRevFlag = 1;
                 break;
             case 't':
                 info.target_revision = strtoull(optarg, NULL, 0);
+                targetRevFlag = 1;
                 break;
             case '1':
                 info.magic_1 = (uint32_t) atoi(optarg);
@@ -2152,8 +2155,12 @@ int kindle_create_main(int argc, char *argv[])
             // We of course need the versioned ota bundle type...
             strncpy(info.magic_number, "FC04", MAGIC_NUMBER_LENGTH);
             // But also a source & target version!
-            info.source_revision = 2443670049;       // FW 5.5.0
-            info.target_revision = 1 + 3018920018;   // FW 5.8.2
+            if( sourceRevFlag == 0 ){
+                info.source_revision = 2443670049;       // FW 5.5.0
+            }
+            if( targetRevFlag == 0 ){
+                info.target_revision = 1 + 3202090019;   // FW 5.8.10
+            }
             // NOTE: Don't expece those to be entirely consistent when crossing devices (f.g., the Touch's FW 5.3.7.3 has a higher OTA build number than the KV's FW 5.5.0)
         }
         // Musn't be *only* a sig envelope...

--- a/KindleTool/kindle_tool.h
+++ b/KindleTool/kindle_tool.h
@@ -224,6 +224,8 @@ typedef enum
     KindlePW3WhiteUnknown_0KE = 0x26E,          // 0KE?
     KindlePW3WhiteUnknown_0KF = 0x26F,          // 0KF?
     KindlePW3WhiteUnknown_0KG = 0x270,          // 0KG?
+    KindlePW3_32GB_Color1 = 0x293,          // 32GB Japan Manga
+    KindlePW3_32GB_Color2 = 0x294,          // 32GB Japan Manga
     // Kindle Oasis, released late spring 2016 on FW 5.7.1.1
     KindleOasisWiFi = 0x20C,            // 0GC
     KindleOasisWiFi3G = 0x20D,          // 0GD


### PR DESCRIPTION
…ith enforce_ota

added flags to determine if source and target revisions are passed on the command line, and use them to honor those settings in the enforce_ota block, instead of hardcoded certain version.