### PR TITLE
Switch hardcoded bash shebangs to use env

### DIFF
--- a/KindleTool/Makefile
+++ b/KindleTool/Makefile
@@ -29,7 +29,7 @@ default: all
 
 # OS, version, pkgconfig & misc stuff handling (heavily inspired from git's Makefiles ;))
 # It's basically our fake automated configure script, and it uses bash features, so override the default shell!
-SHELL:=/bin/bash
+SHELL:=/usr/bin/env bash
 version-inc:
 	@$(SHELL) ./version.sh GIT $(NEED_STATIC_PKGC)
 -include version-inc

--- a/KindleTool/version.sh
+++ b/KindleTool/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Make sure we put our stuff in the proper directory (ie. the same one as this script)
 KT_DIR="${0%/*}"

--- a/tools/kindletool-static-build.sh
+++ b/tools/kindletool-static-build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 OSTYPE="$(uname -s)"
 ARCH="$(uname -m)"

--- a/tools/mingw/kindletool-mingw-build.sh
+++ b/tools/mingw/kindletool-mingw-build.sh
@@ -1,4 +1,6 @@
-#! /bin/bash -e
+#!/usr/bin/env bash
+set -e
+
 #
 # KindleTool cross mingw-w64 buildscript
 #

--- a/tools/simple-linux-static-build.sh
+++ b/tools/simple-linux-static-build.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
+
 #
 # Simple static build.
 # (Only libarchive & nettle will be built/statically linked).


### PR DESCRIPTION
The use of `/usr/bin/env` in shebangs makes them more portable, as it allows even weirder (by historic standards) Linux systems such as NixOS, automatically resolve bash/sh, etc, to the proper paths, rather than relying on a hardcoded path that may or may not exist in the system.