### PR TITLE
Add Nix package/flake for alternative build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 KindleTool.xcodeproj/project.xcworkspace
 KindleTool.xcodeproj/xcuserdata
 
+# Nix Build Output
+result

--- a/KindleTool/Makefile
+++ b/KindleTool/Makefile
@@ -29,7 +29,7 @@ default: all
 
 # OS, version, pkgconfig & misc stuff handling (heavily inspired from git's Makefiles ;))
 # It's basically our fake automated configure script, and it uses bash features, so override the default shell!
-SHELL:=/usr/bin/env bash
+SHELL:=env bash
 version-inc:
 	@$(SHELL) ./version.sh GIT $(NEED_STATIC_PKGC)
 -include version-inc

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769527094,
+        "narHash": "sha256-xV20Alb7ZGN7qujnsi5lG1NckSUmpIb05H2Xar73TDc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "afce96367b2e37fc29afb5543573cd49db3357b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      kindletool = import ./package.nix;
+
+      overlays.default = final: _: {
+        kindletool = final.callPackage kindletool { };
+      };
+
+      forEachSystem = nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      packages = forEachSystem (system: {
+        default = nixpkgs.legacyPackages.${system}.callPackage kindletool { };
+      });
+
+      devShells = forEachSystem (system: {
+        default = nixpkgs.legacyPackages.${system}.mkShell { packages = [ packages.${system}.default ]; };
+      });
+    in
+    {
+      inherit overlays packages devShells;
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,39 @@
+{
+  stdenv,
+  lib,
+  pkg-config,
+  hostname,
+  libarchive,
+  nettle,
+  zlib,
+}:
+stdenv.mkDerivation {
+  name = "kindletool";
+  src = lib.cleanSource ./.;
+
+  nativeBuildInputs = [
+    pkg-config
+    hostname
+  ];
+
+  buildInputs = [
+    libarchive
+    nettle
+    zlib
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    make -C KindleTool all
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+    install -m 755 KindleTool/Release/kindletool $out/bin/kindletool
+    install -m 644 KindleTool/kindletool.1 $out/share/man/man1/kindletool.1
+    runHook postInstall
+  '';
+}

--- a/package.nix
+++ b/package.nix
@@ -7,6 +7,7 @@
   nettle,
   zlib,
 }:
+
 stdenv.mkDerivation {
   name = "kindletool";
   src = lib.cleanSource ./.;
@@ -24,16 +25,27 @@ stdenv.mkDerivation {
 
   buildPhase = ''
     runHook preBuild
+
     make -C KindleTool all
+
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
+
     mkdir -p $out/bin
     mkdir -p $out/share/man/man1
     install -m 755 KindleTool/Release/kindletool $out/bin/kindletool
     install -m 644 KindleTool/kindletool.1 $out/share/man/man1/kindletool.1
+
     runHook postInstall
   '';
+
+  meta = with lib; {
+    homepage = "https://github.com/NiLuJe/KindleTool";
+    description = "A tool for creating & extracting Kindle updates and more";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+  };
 }


### PR DESCRIPTION
Built on top of #28 by Dylan. His build isn't working because of the `/usr/bin/env bash` in the `Makefile`. `env` is available at the Nix derivation build stage, but not at that specific path. Switching to the relative `env bash`, and letting the system use the configured `PATH` to find `env` should work for all distributions, Nix or otherwise.

This could also have been solved at the Nix derivation level, but I figured changing it at the Makefile is fine since it still supports all distributions, and is not a Nix-specific change.

Just to clarify, this doesn't replace the existing build setup. This is just an alternative build for specifically Nix systems. If you don't use Nix, these extra files do absolutely nothing, and will not conflict with any other non-Nix distributions. Rather, it's more like having a `PKGBUILD` file bundled in the repository that would allow for building this project in specifically Arch Linux distros. Same thing here, but for Nix.

Closes #28 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NiLuJe/KindleTool/29)
<!-- Reviewable:end -->
