### PR TITLE
Add Support for Nettle 4.0

### DIFF
--- a/KindleTool/kindle_tool.c
+++ b/KindleTool/kindle_tool.c
@@ -691,7 +691,11 @@ int
 		fprintf(stderr, "Error reading input file: %s.\n", strerror(errno));
 		return -1;
 	}
+#if NETTLE_VERSION_MAJOR == 4
+	md5_digest(&md5, digest);
+#elif NETTLE_VERSION_MAJOR <= 3
 	md5_digest(&md5, MD5_DIGEST_SIZE, digest);
+#endif
 	// And build the hex checksum the nettle way ;)
 	base16_encode_update(output_string, MD5_DIGEST_SIZE, digest);
 
@@ -714,7 +718,11 @@ int
 		fprintf(stderr, "Error reading input file: %s.\n", strerror(errno));
 		return -1;
 	}
+#if NETTLE_VERSION_MAJOR == 4
+	sha256_digest(&sha256, digest);
+#elif NETTLE_VERSION <= 3
 	sha256_digest(&sha256, SHA256_DIGEST_SIZE, digest);
+#endif
 	// And build the hex checksum the nettle way ;)
 	base16_encode_update(output_string, SHA256_DIGEST_SIZE, digest);
 
@@ -1022,7 +1030,11 @@ static int
 	// The root password is based on the MD5 hash of the S/N, so, hash it first.
 	md5_init(&md5);
 	md5_update(&md5, SERIAL_NO_LENGTH + 1, (uint8_t*) serial_no);
+#if NETTLE_VERSION_MAJOR == 4
+	md5_digest(&md5, digest);
+#elif NETTLE_VERSION_MAJOR <= 3
 	md5_digest(&md5, MD5_DIGEST_SIZE, digest);
+#endif
 	base16_encode_update(hash, MD5_DIGEST_SIZE, digest);
 
 	// And finally, do the device dance...

--- a/KindleTool/kindle_tool.c
+++ b/KindleTool/kindle_tool.c
@@ -693,7 +693,7 @@ int
 	}
 #if NETTLE_VERSION_MAJOR == 4
 	md5_digest(&md5, digest);
-#elif NETTLE_VERSION_MAJOR <= 3
+#else
 	md5_digest(&md5, MD5_DIGEST_SIZE, digest);
 #endif
 	// And build the hex checksum the nettle way ;)
@@ -720,7 +720,7 @@ int
 	}
 #if NETTLE_VERSION_MAJOR == 4
 	sha256_digest(&sha256, digest);
-#elif NETTLE_VERSION <= 3
+#else
 	sha256_digest(&sha256, SHA256_DIGEST_SIZE, digest);
 #endif
 	// And build the hex checksum the nettle way ;)
@@ -1032,7 +1032,7 @@ static int
 	md5_update(&md5, SERIAL_NO_LENGTH + 1, (uint8_t*) serial_no);
 #if NETTLE_VERSION_MAJOR == 4
 	md5_digest(&md5, digest);
-#elif NETTLE_VERSION_MAJOR <= 3
+#else
 	md5_digest(&md5, MD5_DIGEST_SIZE, digest);
 #endif
 	base16_encode_update(hash, MD5_DIGEST_SIZE, digest);


### PR DESCRIPTION
This allows for Nettle v4 to be used to compile KindleTool. I have both compiled this on my own machine and my IDE intellisense throws no errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NiLuJe/KindleTool/30)
<!-- Reviewable:end -->
